### PR TITLE
Bugfix [Remove centered text in register page]

### DIFF
--- a/src/routes/[library]/[section]/auth/+layout.svelte
+++ b/src/routes/[library]/[section]/auth/+layout.svelte
@@ -53,7 +53,7 @@
 		</div>
 
 		<!-- Register/Login -->
-		<div class="flex h-full w-full flex-col items-center justify-center text-center xl:w-[80%]">
+		<div class="flex h-full w-full flex-col items-center justify-center xl:w-[80%]">
 			<Loading loadingText={'Thanks for using SUSê!'} loading={Boolean($navigating)} />
 			<slot></slot>
 			<p class="fixed bottom-4 p-4">Made with 🧡 by Zarah Floro and Allaine Tan</p>


### PR DESCRIPTION
Back to normal now! Just removed a `text-center`.

![image](https://github.com/user-attachments/assets/8876d596-8331-4e51-a6bc-0b3971c898fe)
