### PR TITLE
Feature[TLC Route]

### DIFF
--- a/src/lib/components/UIconfig/navConfig.ts
+++ b/src/lib/components/UIconfig/navConfig.ts
@@ -32,7 +32,7 @@ export const studentRoutes: Route[] = [
 		title: 'Send Feedback',
 		id: 'feedback-form',
 		icon: Icons.MessageCircleHeart,
-		url: './feedback-form'
+		url: ''
 	}
 ];
 

--- a/src/lib/stores/AdminStore.ts
+++ b/src/lib/stores/AdminStore.ts
@@ -38,3 +38,5 @@ export const AdminStore: Writable<AdminInformation> = writable({
 })
 
 export const AdminTableStore: Writable<Array<AdminTable>> = writable([]);
+
+export const isPCVerified: Writable<{isCalled: boolean, isVerified:boolean}> = writable({ isCalled: false, isVerified: false});

--- a/src/lib/stores/CollegeProgramStore.ts
+++ b/src/lib/stores/CollegeProgramStore.ts
@@ -71,6 +71,7 @@ export const collegePrograms: Readable<College[]> = readable([
 		value: '7',
 		programs: [
 			{ label: 'Artificial Intelligence (MEng, PhD)', value: '20' },
+			{ label: 'Bioinformatics (MS)', value: '83' },
 			{ label: 'Chemical Engineering (BS)', value: '21' },
 			{ label: 'Chemical Engineering (MS, PhD)', value: '22' },
 			{ label: 'Civil Engineering (BS)', value: '23' },
@@ -78,7 +79,6 @@ export const collegePrograms: Readable<College[]> = readable([
 			{ label: 'Computer Engineering (BS)', value: '25' },
 			{ label: 'Computer Science (BS)', value: '26' },
 			{ label: 'Computer Science (MS, PhD)', value: '82' },
-			{ label: 'Bioinformatics (MS)', value: '83' },
 			{ label: 'Electrical Engineering (BS)', value: '27' },
 			{ label: 'Electrical Engineering (ME, MS, PhD)', value: '28' },
 			{ label: 'Environmental Engineering (Dip, MS, PhD)', value: '29' },

--- a/src/lib/stores/LibrarySectionStore.ts
+++ b/src/lib/stores/LibrarySectionStore.ts
@@ -9,5 +9,5 @@ export const SectionStore: Readable<{[key:number]:string}> = readable({
     1: 'circulation',
     2: 'serials',
     3: 'the-learning-commons',
-    4: 'ground-floor-service',
+    4: 'ground-floor-services',
 })

--- a/src/lib/utilsBack.ts
+++ b/src/lib/utilsBack.ts
@@ -5,13 +5,15 @@ export function convertRfidInt(hex: string) {
     return reverseHex ? parseInt(reverseHex, 16).toString() : "0"
 }
 
-export function countDiscRoomAvailability(discRoomOption:{[key:string]: ServiceOption}, library:string):number {
-    let currentCount:number = 0;
+export function countDiscRoomAvailability(discRoomOption: { [key: string]: ServiceOption }, library: string): number {
+    let currentCount: number = 0;
     for (const subset of Object.values(discRoomOption)) {
-        if ((library == 'engglib2' && subset.options.length == 10) ||
-            (library == 'engglib1' && 
-            (((subset.label == 'Ergonomics DR' || subset.label == 'Kinematics DR') && subset.options.length == 8) ||
-            ((subset.label != 'Ergonomics DR' && subset.label != 'Kinematics DR') && subset.options.length == 6)))
+        if ((library == 'engglib2' &&
+            ((subset.label.includes("TLC DR") && subset.options.length == 8) ||
+                (!subset.label.includes("TLC DR") && subset.options.length == 10))) ||
+            (library == 'engglib1' &&
+                (((subset.label == 'Ergonomics DR' || subset.label == 'Kinematics DR') && subset.options.length == 8) ||
+                    ((subset.label != 'Ergonomics DR' && subset.label != 'Kinematics DR') && subset.options.length == 6)))
         ) {
             currentCount++;
         }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,12 +21,17 @@
 				<Button
 					on:click={() => {
 						goto('/engglib1/circulation/auth/login');
-					}}>Engineering Library I</Button
+					}}>EnggLib I Circulation</Button
 				>
 				<Button
 					on:click={() => {
 						goto('/engglib2/circulation/auth/login');
-					}}>Engineering Library II</Button
+					}}>EnggLib II Circulation</Button
+				>
+				<Button
+					on:click={() => {
+						goto('/engglib2/the-learning-commons/auth/login');
+					}}>EnggLib II TLC</Button
 				>
 			</div>
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,6 +25,11 @@
 				>
 				<Button
 					on:click={() => {
+						goto('/engglib1/ground-floor-service/auth/login');
+					}}>EnggLib I GFS</Button
+				>
+				<Button
+					on:click={() => {
 						goto('/engglib2/circulation/auth/login');
 					}}>EnggLib II Circulation</Button
 				>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,7 +25,7 @@
 				>
 				<Button
 					on:click={() => {
-						goto('/engglib1/ground-floor-service/auth/login');
+						goto('/engglib1/ground-floor-services/auth/login');
 					}}>EnggLib I GFS</Button
 				>
 				<Button

--- a/src/routes/[library]/[section]/+layout.ts
+++ b/src/routes/[library]/[section]/+layout.ts
@@ -7,7 +7,7 @@ export const load: LayoutLoad = ({ params }) => {
         section = 'Circulation';
     } else if (params.section === 'the-learning-commons') {
         section = 'The Learning Commons';
-    } else if (params.section === 'ground-floor-service') {
+    } else if (params.section === 'ground-floor-services') {
         section = 'Ground Floor Service';
     }
 

--- a/src/routes/[library]/[section]/+layout.ts
+++ b/src/routes/[library]/[section]/+layout.ts
@@ -2,23 +2,31 @@ import { error } from '@sveltejs/kit';
 import type { LayoutLoad } from '../$types';
 
 export const load: LayoutLoad = ({ params }) => {
-	if (params.library === 'engglib1') {
-		return {
-			libraryName: 'Engineering Library I',
-			libraryBuilding: ' 2/F Melchor Hall, ',
-			libraryStreet: 'S. Osmeña Avenue, UP Diliman',
-			librarySrc: '../../../photos/MH.jpg',
-			librarySection: params.section
-		};
-	}
-	if (params.library === 'engglib2') {
-		return {
-			libraryName: 'Engineering Library II',
-			libraryBuilding: 'G/F UP Alumni Engineers Centennial Hall,',
-			libraryStreet: 'Velasquez St., UP Diliman',
-			librarySrc: '../../../photos/AECH.jpeg',
-			librarySection: params.section
-		};
-	}
+    let section:string = '';
+    if (params.section === 'circulation') {
+        section = 'Circulation';
+    } else if (params.section === 'the-learning-commons') {
+        section = 'The Learning Commons';
+    }
+
+	if (section) {
+        if (params.library === 'engglib1') {
+            return {
+                libraryName: 'Engineering Library I',
+                libraryBuilding: ' 2/F Melchor Hall, ',
+                libraryStreet: 'S. Osmeña Avenue, UP Diliman',
+                librarySrc: '../../../photos/MH.jpg',
+                librarySection: section
+            };
+        } else if (params.library === 'engglib2') {
+            return {
+                libraryName: 'Engineering Library II',
+                libraryBuilding: 'G/F UP Alumni Engineers Centennial Hall,',
+                libraryStreet: 'Velasquez St., UP Diliman',
+                librarySrc: '../../../photos/AECH.jpeg',
+                librarySection: section
+            };
+        }
+    }
 	error(404, 'Not found');
 };

--- a/src/routes/[library]/[section]/+layout.ts
+++ b/src/routes/[library]/[section]/+layout.ts
@@ -7,6 +7,8 @@ export const load: LayoutLoad = ({ params }) => {
         section = 'Circulation';
     } else if (params.section === 'the-learning-commons') {
         section = 'The Learning Commons';
+    } else if (params.section === 'ground-floor-service') {
+        section = 'Ground Floor Service';
     }
 
 	if (section) {

--- a/src/routes/[library]/[section]/auth/login/+page.svelte
+++ b/src/routes/[library]/[section]/auth/login/+page.svelte
@@ -13,11 +13,12 @@
 	import { readUsername } from '../../../../supabase/User';
 	import { page } from '$app/stores';
 	import { deleteCookie } from '$lib/client/Cookie';
-	import { AdminStore, AdminTableStore } from '$lib/stores/AdminStore';
+	import { AdminStore, AdminTableStore, isPCVerified } from '$lib/stores/AdminStore';
 	import { readEmail } from '../../../../supabase/Admin';
 	import { convertRfidInt } from '$lib/utilsBack';
 	import { ServiceTableStore } from '$lib/stores/ServiceStore';
 	import { UsageLogTableStore } from '$lib/stores/UsageLogStore';
+	import { verifyPC } from '../../../../supabase/Verifier';
 
 	let loginWithRfid: boolean = true;
 	let rfidGlobal: string = '';
@@ -185,6 +186,10 @@
 	function handleKeydownRfid(event: KeyboardEvent) {
 		// Listens to input in the RFID field
 		if (event.key === 'Enter' || rfidGlobal.length == 10) {
+            if (!$isPCVerified.isVerified) {
+                toast.error('PC not allowed to access SUSê.')
+                return;
+            }
 			if (rfidGlobal.match(/[a-fA-F]+/i)) {
 				rfidConverted = convertRfidInt(rfidGlobal);
 			} else {
@@ -204,6 +209,10 @@
 	function handleKeydownUsername(event: KeyboardEvent) {
 		// Listens to input in the UP mail field
 		if (event.key === 'Enter') {
+            if (!$isPCVerified.isVerified) {
+                toast.error('PC not allowed to access SUSê.')
+                return;
+            }
 			checkUsernameCount++;
 			checkUsername();
 		}
@@ -253,6 +262,16 @@
 		if (browser) {
 			selectText('userRfid');
 			document.addEventListener('mousedown', handleClickOutside);
+            if (!$isPCVerified.isCalled) {
+                verifyPC().then((res) => {
+                    $isPCVerified.isCalled = true;
+                    if (res.error) {
+                        toast.error(res.error)
+                    } else {
+                        $isPCVerified.isVerified = true;
+                    }
+                })
+            }
 		}
 	});
 

--- a/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
+++ b/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
@@ -32,7 +32,7 @@
 	import type { UsageLogView } from '$lib/dataTypes/EntityTypes';
 	import { countDiscRoomAvailability } from '$lib/utilsBack';
 
-	export let data: { libraryName: string };
+	export let data: { libraryName: string, librarySection:string };
 
 	let serviceSelected = '';
 	let termsAccepted = false;
@@ -144,7 +144,6 @@
 				$ServiceTypeStore = serviceTypes;
 				$ServiceInfoStore = serviceInfo;
 				$ServiceOptionStore = serviceOption;
-                console.log($ServiceTypeStore)
 			}
 		}
 		return;
@@ -259,7 +258,7 @@
 	<div class="flex h-full w-full flex-col gap-10 p-10 md:p-20">
 		<div class="flex w-full grow flex-col gap-4">
 			<h1 class="text-3xl font-medium">
-				Welcome to {data.libraryName}, {$UserStore.formData.first_name}!
+				Welcome to {data.libraryName} {data.librarySection}, {$UserStore.formData.first_name}!
 			</h1>
 
 			{#if $UserStore.formData.is_approved}

--- a/src/routes/supabase/User.ts
+++ b/src/routes/supabase/User.ts
@@ -3,12 +3,12 @@ import type { UserFilter } from "$lib/dataTypes/EntityFilters";
 import type { UserResponse } from "$lib/dataTypes/EntityResponses";
 import type { UserFormData } from "$lib/stores/UserStore";
 
-type Username = { 
-    username: string, 
-    error: string | null 
+type Username = {
+    username: string,
+    error: string | null
 }
 
-export async function readUsername(rfid:string='', username:string=''): Promise<Username> {
+export async function readUsername(rfid: string = '', username: string = ''): Promise<Username> {
     // Reads the public_user_info view in the database and returns the username of the user
     let query = supabaseClient.from('public_user_info').select("username");
 
@@ -33,7 +33,7 @@ export async function readUsername(rfid:string='', username:string=''): Promise<
     }
 }
 
-export async function readUser(filter:UserFilter): Promise<UserResponse> {
+export async function readUser(filter: UserFilter): Promise<UserResponse> {
     // Reads and filters the user_info view in the database and returns all corresponding entries
     let query = supabaseClient.from('user_info').select("*");
 
@@ -74,7 +74,7 @@ export async function readUser(filter:UserFilter): Promise<UserResponse> {
     }
 }
 
-export async function createUser(userInfo:UserFormData): Promise<UserResponse> {
+export async function createUser(userInfo: UserFormData): Promise<UserResponse> {
     // Creates user information in the lib_user table.
 
     const { error } = await supabaseClient.from('lib_user').insert({
@@ -105,7 +105,7 @@ export async function createUser(userInfo:UserFormData): Promise<UserResponse> {
     };
 }
 
-export async function updateUser(userInfo: object, username: string, lib_user_id:number=0): Promise<UserResponse> {
+export async function updateUser(userInfo: object, username: string, lib_user_id: number = 0): Promise<UserResponse> {
     // Updates user information in the lib_user table
     let query = supabaseClient.from('lib_user').update(userInfo)
 
@@ -129,7 +129,7 @@ export async function updateUser(userInfo: object, username: string, lib_user_id
     };
 }
 
-export async function deleteUser(lib_user_id:number): Promise<UserResponse> {
+export async function deleteUser(lib_user_id: number): Promise<UserResponse> {
     // Deletes user record from user_engglib table
     const { error } = await supabaseClient.from('lib_user').delete().eq('lib_user_id', lib_user_id)
 

--- a/src/routes/supabase/Verifier.ts
+++ b/src/routes/supabase/Verifier.ts
@@ -36,10 +36,13 @@ export async function verifyPC(): Promise<{ error: string }> {
             error: error.message
         }
     }
-    else if (data.length && !data[0].is_allowed) {
-        return {
-            error: 'PC not allowed to access SUSê.'
-        }
+    // else if (data.length && !data[0].is_allowed) {
+    //     return {
+    //         error: 'PC not allowed to access SUSê.'
+    //     }
+    // } 
+    else if (data.length == 0) {
+        await addPCCookie();
     }
     return {
         error: ''

--- a/src/routes/supabase/Verifier.ts
+++ b/src/routes/supabase/Verifier.ts
@@ -1,19 +1,21 @@
 import { createCookie, deleteCookie, readCookie } from "$lib/client/Cookie";
 import { supabaseClient } from "$lib/client/SupabaseClient";
 
-async function addPCCookie(): Promise<{ error:string }> {
+async function addPCCookie(): Promise<{ newID: string, error: string }> {
     // Adds a unique ID for a PC
-    const newID:string = Math.ceil(Math.random() * (10 ** 15)).toString();
+    const newID: string = Math.ceil(Math.random() * (10 ** 15)).toString();
     createCookie('pcCookie', newID, 24 * 30, '/')
-    
+
     const { error } = await supabaseClient.from('cookie').insert({ cookie_id: newID })
 
     if (error) {
         return {
+            newID: '',
             error: error.message
         }
     } else {
         return {
+            newID,
             error: ''
         }
     }
@@ -21,25 +23,23 @@ async function addPCCookie(): Promise<{ error:string }> {
 
 export async function verifyPC(): Promise<{ error: string }> {
     // Verifies this PC is an EnggLib managed PC by checking the generated cookie
-    let pcCookie:number = parseInt(readCookie('pcCookie'));
-    if (pcCookie) {
-        // console.log('readCookie', pcCookie)
-        const { data, error } = await supabaseClient
-            .from('cookie')
-            .select('is_allowed')
-            .eq('cookie_id', pcCookie)
-        if (error) {
-            return {
-                error: error.message
-            }
-        } 
-        else if (data.length && !data[0].is_allowed) {
-            return {
-                error: 'PC not allowed to access SUSê.'
-            }
+    let pcCookie: number = parseInt(readCookie('pcCookie'));
+    if (!pcCookie) {
+        pcCookie = parseInt((await addPCCookie()).newID);
+    }
+    const { data, error } = await supabaseClient
+        .from('cookie')
+        .select('is_allowed')
+        .eq('cookie_id', pcCookie)
+    if (error) {
+        return {
+            error: error.message
         }
-    } else {
-        addPCCookie();
+    }
+    else if (data.length && !data[0].is_allowed) {
+        return {
+            error: 'PC not allowed to access SUSê.'
+        }
     }
     return {
         error: ''

--- a/src/routes/supabase/Verifier.ts
+++ b/src/routes/supabase/Verifier.ts
@@ -1,0 +1,47 @@
+import { createCookie, deleteCookie, readCookie } from "$lib/client/Cookie";
+import { supabaseClient } from "$lib/client/SupabaseClient";
+
+async function addPCCookie(): Promise<{ error:string }> {
+    // Adds a unique ID for a PC
+    const newID:string = Math.ceil(Math.random() * (10 ** 15)).toString();
+    createCookie('pcCookie', newID, 24 * 30, '/')
+    
+    const { error } = await supabaseClient.from('cookie').insert({ cookie_id: newID })
+
+    if (error) {
+        return {
+            error: error.message
+        }
+    } else {
+        return {
+            error: ''
+        }
+    }
+}
+
+export async function verifyPC(): Promise<{ error: string }> {
+    // Verifies this PC is an EnggLib managed PC by checking the generated cookie
+    let pcCookie:number = parseInt(readCookie('pcCookie'));
+    if (pcCookie) {
+        // console.log('readCookie', pcCookie)
+        const { data, error } = await supabaseClient
+            .from('cookie')
+            .select('is_allowed')
+            .eq('cookie_id', pcCookie)
+        if (error) {
+            return {
+                error: error.message
+            }
+        } 
+        else if (data.length && !data[0].is_allowed) {
+            return {
+                error: 'PC not allowed to access SUSê.'
+            }
+        }
+    } else {
+        addPCCookie();
+    }
+    return {
+        error: ''
+    }
+}


### PR DESCRIPTION
The EnggLib is requesting a new route for availing services in TLC 2. 

# Updates
- Route validations for sections. Only `circulation`, `the-learning-commons`, and `ground-floor-service` are valid section routes.
- Added a button in the landing page to redirect to the login page for TLC and GFS.

# Requests
- Add specific images or text indicating the section for EnggLib 1 Circulation, EnggLib2 Circulation, and EnggLib2 TLC to display the sections where users are availing a service in. (UX)
- Reorganize Landing page buttons for possible addition of future sections. (I'm proposing to add a ground-floor-services section in EnggLib 1)