### PR TITLE
Feature[Report Generation]

### DIFF
--- a/src/lib/components/UIconfig/icons.ts
+++ b/src/lib/components/UIconfig/icons.ts
@@ -22,3 +22,4 @@ export { default as ChevronsRight } from 'lucide-svelte/icons/chevrons-right';
 export { default as ChevronLeft } from 'lucide-svelte/icons/chevron-left';
 export { default as ChevronsLeft } from 'lucide-svelte/icons/chevrons-left';
 export { default as IDCard } from 'lucide-svelte/icons/id-card';
+export { default as AlignEndHorizontal } from 'lucide-svelte/icons/align-end-horizontal';

--- a/src/lib/components/UIconfig/navConfig.ts
+++ b/src/lib/components/UIconfig/navConfig.ts
@@ -60,5 +60,11 @@ export const adminRoutes: Route[] = [
 		id: 'administrators',
 		icon: Icons.ShoppingCart,
 		url: './administrators'
+	},
+	{
+		title: 'Statistics',
+		id: 'statistics',
+		icon: Icons.AlignEndHorizontal,
+		url: './statistics'
 	}
 ];

--- a/src/lib/components/ui/combobox/library-combobox.svelte
+++ b/src/lib/components/ui/combobox/library-combobox.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import * as Popover from '$lib/components/ui/popover';
+	import * as Command from '$lib/components/ui/command';
+	import { ChevronsUpDown, Check } from 'lucide-svelte';
+	import { cn } from '$lib/utilsFront';
+	import { libraryTypes } from '$lib/stores/LibrarySectionStore';
+
+	let comboboxOpen = false;
+	export let selectedLibrary = '';
+	export let onChange: (value: string) => void = () => {};
+</script>
+
+<Popover.Root bind:open={comboboxOpen}>
+	<Popover.Trigger
+		class=" border-1 flex justify-between rounded-sm border border-slate-200 p-2"
+		role="combobox"
+	>
+		<p class="truncate text-sm my-auto">
+			{libraryTypes.find((f) => f.value === selectedLibrary)?.label ?? 'Select a library'}
+		</p>
+		<ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+	</Popover.Trigger>
+
+	<Popover.Content>
+		<Command.Root shouldFilter={false}>
+			<Command.Empty>No library found.</Command.Empty>
+			<Command.List>
+				<Command.Group>
+					{#each libraryTypes as libraryType}
+						<Command.Item
+							value={libraryType.label}
+							onSelect={() => {
+								selectedLibrary = libraryType.label;
+								onChange(libraryType.value);
+								comboboxOpen = false;
+							}}
+						>
+							{libraryType.label}
+							<Check
+								class={cn(
+									'ml-auto h-4 w-4',
+									libraryType.value !== selectedLibrary && 'text-transparent'
+								)}
+							/>
+						</Command.Item>
+					{/each}
+				</Command.Group>
+			</Command.List>
+		</Command.Root>
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/components/ui/combobox/section-combobox.svelte
+++ b/src/lib/components/ui/combobox/section-combobox.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import * as Popover from '$lib/components/ui/popover';
+	import * as Command from '$lib/components/ui/command';
+	import { ChevronsUpDown, Check } from 'lucide-svelte';
+	import { cn } from '$lib/utilsFront';
+	import { sectionTypes } from '$lib/stores/LibrarySectionStore';
+
+	let comboboxOpen = false;
+	export let selectedSection = '';
+	export let onChange: (value: string) => void = () => {};
+</script>
+
+<Popover.Root bind:open={comboboxOpen}>
+	<Popover.Trigger
+		class=" border-1 flex justify-between rounded-sm border border-slate-200 p-2"
+		role="combobox"
+	>
+		<p class="truncate text-sm my-auto">
+			{sectionTypes.find((f) => f.value === selectedSection)?.label ?? 'Select a section'}
+		</p>
+		<ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
+	</Popover.Trigger>
+
+	<Popover.Content>
+		<Command.Root shouldFilter={false}>
+			<Command.Empty>No library found.</Command.Empty>
+			<Command.List>
+				<Command.Group>
+					{#each sectionTypes as sectionType}
+						<Command.Item
+							value={sectionType.label}
+							onSelect={() => {
+								selectedSection = sectionType.label;
+								onChange(sectionType.value);
+								comboboxOpen = false;
+							}}
+						>
+							{sectionType.label}
+							<Check
+								class={cn(
+									'ml-auto h-4 w-4',
+									sectionType.value !== selectedSection && 'text-transparent'
+								)}
+							/>
+						</Command.Item>
+					{/each}
+				</Command.Group>
+			</Command.List>
+		</Command.Root>
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/components/ui/date-picker/date-picker.svelte
+++ b/src/lib/components/ui/date-picker/date-picker.svelte
@@ -26,7 +26,7 @@
 	<Popover.Trigger asChild let:builder>
 		<Button
 			variant="outline"
-			class={cn('w-[280px] justify-start text-left font-normal', !value && 'text-muted-foreground')}
+			class={cn('justify-start text-left font-normal', !value && 'text-muted-foreground')}
 			builders={[builder]}
 		>
 			<CalendarIcon class="mr-2 h-4 w-4" />

--- a/src/lib/components/ui/date-picker/date-picker.svelte
+++ b/src/lib/components/ui/date-picker/date-picker.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import CalendarIcon from 'lucide-svelte/icons/calendar';
+	import { DateFormatter, type DateValue, getLocalTimeZone } from '@internationalized/date';
+	import { cn } from '$lib/utilsFront.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Calendar } from '$lib/components/ui/calendar/index.js';
+	import * as Popover from '$lib/components/ui/popover/index.js';
+
+	const df = new DateFormatter('en-US', {
+		dateStyle: 'long'
+	});
+
+	let value: DateValue | undefined = undefined;
+
+	export let selectedDate: Date | null = null;
+    export let placeholder: string = 'Enter date';
+
+	$: {
+		if (value) {
+            selectedDate = new Date(value.year, value.month, value.day)
+		}
+	}
+</script>
+
+<Popover.Root>
+	<Popover.Trigger asChild let:builder>
+		<Button
+			variant="outline"
+			class={cn('w-[280px] justify-start text-left font-normal', !value && 'text-muted-foreground')}
+			builders={[builder]}
+		>
+			<CalendarIcon class="mr-2 h-4 w-4" />
+			{value ? df.format(value.toDate(getLocalTimeZone())) : placeholder}
+		</Button>
+	</Popover.Trigger>
+	<Popover.Content class="w-auto p-0">
+		<Calendar bind:value initialFocus />
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/dataTypes/EntityFilters.ts
+++ b/src/lib/dataTypes/EntityFilters.ts
@@ -34,5 +34,5 @@ export type UsageLogFilter = {
     service_type: string,
     library: string,
     section: string, 
-    admin_id:number
+    admin_nickname:string
 }

--- a/src/lib/dataTypes/EntityFilters.ts
+++ b/src/lib/dataTypes/EntityFilters.ts
@@ -34,4 +34,5 @@ export type UsageLogFilter = {
     service_type: string,
     library: string,
     section: string, 
+    admin_id:number
 }

--- a/src/lib/stores/LibrarySectionStore.ts
+++ b/src/lib/stores/LibrarySectionStore.ts
@@ -8,7 +8,19 @@ export const LibraryStore: Readable<{[key:number]:string}> = readable({
 export const SectionStore: Readable<{[key:number]:string}> = readable({
     1: 'circulation',
     2: 'serials',
-    3: 'tlc1',
-    4: 'tlc2',
-    5: 'ground-floor-service',
+    3: 'the-learning-commons',
+    4: 'ground-floor-service',
 })
+
+export const libraryTypes = [
+	{ value: 'engglib1', label: 'EnggLib 1' },
+	{ value: 'engglib2', label: 'EnggLib 2' },
+];
+
+export const sectionTypes = [
+	{ value: '', label: 'All Sections in Library' },
+	{ value: 'circulation', label: 'Circulation' },
+	{ value: 'serials', label: 'Serials' },
+	{ value: 'the-learning-commons', label: 'The Learning Commons' },
+	{ value: 'ground-floor-service', label: 'Ground Floor Services' },
+];

--- a/src/lib/stores/StatisticStore.ts
+++ b/src/lib/stores/StatisticStore.ts
@@ -1,0 +1,11 @@
+import { writable, type Writable } from "svelte/store";
+
+type StatisticStore = {
+    total_usagelogs:number,
+    // total_services:number,
+}
+
+export const StatisticStore: Writable<StatisticStore> = writable({
+    total_usagelogs:0,
+    // total_services
+})

--- a/src/lib/stores/StatisticStore.ts
+++ b/src/lib/stores/StatisticStore.ts
@@ -1,11 +1,11 @@
 import { writable, type Writable } from "svelte/store";
 
 type StatisticStore = {
-    total_usagelogs:number,
-    total_services: {[key:string]: number},
+    total_usagelogs: number,
+    total_services: { [key: string]: number },
 }
 
 export const StatisticStore: Writable<StatisticStore> = writable({
-    total_usagelogs:0,
+    total_usagelogs: 0,
     total_services: {}
 })

--- a/src/lib/stores/StatisticStore.ts
+++ b/src/lib/stores/StatisticStore.ts
@@ -2,10 +2,10 @@ import { writable, type Writable } from "svelte/store";
 
 type StatisticStore = {
     total_usagelogs:number,
-    // total_services:number,
+    total_services: {[key:string]: number},
 }
 
 export const StatisticStore: Writable<StatisticStore> = writable({
     total_usagelogs:0,
-    // total_services
+    total_services: {}
 })

--- a/src/lib/stores/UsageLogStore.ts
+++ b/src/lib/stores/UsageLogStore.ts
@@ -1,6 +1,6 @@
 import type { UsageLogView } from "$lib/dataTypes/EntityTypes"
 import { writable, type Writable } from "svelte/store"
 
-export const ActiveUsageLogStore: Writable<{ [key: string]: UsageLogView }> = writable();
+export const ActiveUsageLogStore: Writable<{ [key: string]: UsageLogView }> = writable({});
 
 export const UsageLogTableStore: Writable<Array<UsageLogView>> = writable([]);

--- a/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
@@ -268,8 +268,8 @@
 				email: $AdminStore.formData.email,
 				is_active: null,
 				is_approved: null,
-				library: '',
-				section: ''
+				library,
+				section
 			});
 
 			if (error) {

--- a/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
@@ -9,7 +9,7 @@
 	// Backend Imports
 	import { navigating, page } from '$app/stores';
 	import { beforeNavigate, goto } from '$app/navigation';
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import { createCookie, deleteCookie, readCookie } from '$lib/client/Cookie';
 	import { supabaseClient } from '$lib/client/SupabaseClient';
 	import type { RealtimeChannel, Session, User } from '@supabase/supabase-js';
@@ -21,11 +21,10 @@
 	import type { AdminTable, ServiceTable, ServiceView, UsageLogTable, UsageLogView, UserTable, UserView } from '$lib/dataTypes/EntityTypes';
 	import { readUser } from '../../../supabase/User';
 	import { UserTableStore } from '$lib/stores/UserStore';
-	import { countUsageLog, readUsageLog } from '../../../supabase/UsageLog';
+	import { readUsageLog } from '../../../supabase/UsageLog';
 	import { UsageLogTableStore } from '$lib/stores/UsageLogStore';
 	import { readService } from '../../../supabase/Service';
-	import { ServiceTableStore } from '$lib/stores/ServiceStore';
-	import { StatisticStore } from '$lib/stores/StatisticStore';
+	import { ServiceTableStore, ServiceTypeStore } from '$lib/stores/ServiceStore';
 	// ----------------------------------------------------------------------------
 	// NAVBAR
 	// ----------------------------------------------------------------------------
@@ -66,6 +65,11 @@
 		attachActivityListeners();
 		startLogOutTimer();
 		getAdmin();
+
+        getAdminTable();
+        getUserTable();
+        getUsageTable();
+        subscribeRealtimeUpdates();
 	}
 
 	function createNewCookies(session: Session | null) {
@@ -530,52 +534,11 @@
 		return;
 	}
 
-    async function getStatistics() {
-        // gets all statistics for the logged in admin
-        const { count, error } = await countUsageLog({
-            usagelog_id: 0,
-            start: null,
-            end: null,
-            is_active: null,
-            lib_user_id: 0,
-            service_type: '',
-            library,
-            section,
-            admin_id: $AdminStore.formData.admin_id
-        });
-
-        if (error) {
-            toast.error(`Error with getting statistics: ${error}`);
-        } else if (count) {
-            $StatisticStore.total_usagelogs = count;
-        }
-        return;
-    }
-
 	// ----------------------------------------------------------------------------
 
 	$: {
 		if (browser && document) {
 			startAdminSession();
-		}
-	}
-    let values:number|null = null
-	$: {
-		if ($AdminStore.authenticated) {
-            if (!$AdminTableStore.length) {
-                getAdminTable();
-            }
-            if (!$UserTableStore.length) {
-                getUserTable();
-            }
-            if (!$UsageLogTableStore.length) {
-                getUsageTable();
-            }
-            if (values == null) {
-                values = 1
-                getStatistics()
-            }
-			subscribeRealtimeUpdates();
 		}
 	}
 </script>

--- a/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
@@ -68,7 +68,7 @@
 		$AdminStore.authenticated = true;
 		$AdminStore.formData.email = admin?.email ? admin.email : '';
 		$AdminStore = $AdminStore;
-
+        
 		toast(`You will be logged out after 15 minutes of inactivity.`, { icon: '⏳' });
 		attachActivityListeners();
 		startLogOutTimer();
@@ -76,6 +76,7 @@
 			getAdminTable();
 			getUserTable();
 			getUsageTable();
+            getServiceTable()
 			subscribeRealtimeUpdates();
 		});
 	}
@@ -111,7 +112,7 @@
 		const accessTokenAdmin: string = readCookie('accessTokenAdmin');
 		const refreshTokenAdmin: string = readCookie('refreshTokenAdmin');
 
-		if (session) {
+		if (session && !accessTokenAdmin && !refreshTokenAdmin) {
 			// if there is currently a session with no cookies, save tokens in cookies
 			createNewCookies(session);
 			getSessionData(admin);
@@ -120,7 +121,7 @@
 			toast.error('Please login first.');
 			isLoggedOut = true;
 			goto(`/${library}/${section}/auth/login`);
-		} else if (accessTokenAdmin && refreshTokenAdmin) {
+		} else if (!session && accessTokenAdmin && refreshTokenAdmin) {
 			// if there is no current session, start one with the saved tokens
 			const {
 				data: { session },
@@ -330,7 +331,6 @@
 
 	async function updateUsageLogsRealtime(updatedUsagelog: UsageLogTable, eventType: EventType) {
 		// Updates the usage log record in the Usage Log Table store
-        console.log(updatedUsagelog)
         if (eventType == 'DELETE') {
             $UsageLogTableStore = $UsageLogTableStore.filter((value) => value.usagelog_id != updatedUsagelog.usagelog_id);
         } else {

--- a/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/+layout.svelte
@@ -336,7 +336,7 @@
 			service_type: '',
 			library,
 			section,
-			admin_id: 0
+			admin_nickname: ''
 		});
 
 		if (error) {
@@ -540,7 +540,7 @@
 			service_type: '',
 			library,
 			section,
-			admin_id: 0
+			admin_nickname: ''
 		});
 
 		if (error) {

--- a/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	// UI Imports
+	import { Toaster } from 'svelte-5-french-toast';
+	import * as Alert from '$lib/components/ui/alert';
+	import CircleAlert from 'lucide-svelte/icons/circle-alert';
+	// Backend Imports
+	import { AdminStore } from '$lib/stores/AdminStore';
+	import { StatisticStore } from '$lib/stores/StatisticStore';
+
+    export let data: { libraryName: string, librarySection: string };
+    let section:string = data.librarySection
+        .split('-')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+</script>
+
+<Toaster />
+
+<div class="flex w-full justify-center">
+	{#if $AdminStore.formData.is_approved}
+		<div class="w-[95%] flex flex-col gap-4">
+			<h1 class="pt-10 text-3xl font-medium">Hello, {$AdminStore.formData.nickname}</h1>
+            <h2 class="text-lg text-[#636363]">Here are your statistics in {data.libraryName}, {section}</h2>
+            <p>Total Usage Logs Supervised: {$StatisticStore.total_usagelogs}</p>
+		</div>
+	{:else}
+		<div class="flex h-full w-full flex-col gap-10 p-20">
+			<div class="flex w-full grow flex-col gap-4">
+				<Alert.Root variant="destructive">
+					<CircleAlert class="h-4 w-4" />
+					<Alert.Title>Heads up!</Alert.Title>
+					<Alert.Description>
+						Please contact another library admin to have your account approved and soon view library
+						records.
+					</Alert.Description>
+				</Alert.Root>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
@@ -86,8 +86,8 @@
 				Here are your statistics in {data.libraryName}, {librarySection}
 			</h2>
             <div class="grid grid-cols-4">
-                <LibraryCombobox bind:selectedLibrary={selectedLibrary} onChange={(e) => {selectedLibrary = e; console.log(selectedLibrary)}} />
-                <SectionCombobox bind:selectedSection={selectedSection} onChange={(e) => {selectedSection = e; console.log(selectedSection)}} />
+                <LibraryCombobox bind:selectedLibrary={selectedLibrary} onChange={(e) => selectedLibrary = e} />
+                <SectionCombobox bind:selectedSection={selectedSection} onChange={(e) => selectedSection = e} />
                 <Input placeholder="Enter admin nickname" class="max-w-sm" bind:value={selectedAdmin}/>
                 <Button on:click={getStatistics}>Get Statistics</Button>
             </div>

--- a/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
@@ -8,62 +8,83 @@
 	import { StatisticStore } from '$lib/stores/StatisticStore';
 	import { countTotalUsageLog } from '../../../../supabase/UsageLog';
 	import { page } from '$app/stores';
-        
-    const routes: Array<string> = $page.url.pathname.split('/');
+	import { readServiceType } from '../../../../supabase/ServiceType';
+	import { ServiceTypeStore } from '$lib/stores/ServiceStore';
+
+	const routes: Array<string> = $page.url.pathname.split('/');
 	const library: string = routes[1]; // session
 	const section: string = routes[2]; // session
 
-    export let data: { libraryName: string };
-    const librarySection:string = section
-        .split('-')
-        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(' ');
+	export let data: { libraryName: string };
+	const librarySection: string = section
+		.split('-')
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ');
 
-        async function getStatistics() {
-        // gets all statistics for the logged in admin
-        const { count, error } = await countTotalUsageLog({
-            usagelog_id: 0,
-            start: null,
-            end: null,
-            is_active: null,
-            lib_user_id: 0,
-            service_type: '',
-            library,
-            section,
-            admin_id: $AdminStore.formData.admin_id
-        });
+	async function getServiceType() {
+		// gets the service types from the db as it's needed in both admin and user dashboard
+		const { serviceTypes, error } = await readServiceType();
 
-        if (error) {
-            toast.error(`Error with getting statistics: ${error}`);
-        } else if (count) {
-            $StatisticStore.total_usagelogs = count;
-
-            // const { serviceTypes, error } = await readServiceType();
-            // if (error) {
-            //     return;
-            // } else if (serviceTypes != null) {
-
-            //     $ServiceTypeStore = serviceTypes;
-            //     console.log($ServiceTypeStore)
-
-            //     // for (const service of $ServiceTypeStore) {
-            //     //     console.log(service)
-            //     // }
-            // }
-        }
+		if (error) {
+			toast.error(`Error with reading service types: ${error}`);
+		} else if (serviceTypes) {
+            $ServiceTypeStore = serviceTypes;
+            console.log($ServiceTypeStore)
+		}
         return;
+	}
+
+    if ($ServiceTypeStore.length == 0) {
+        getServiceType();
     }
+
+	async function getStatistics() {
+		// gets all statistics for the logged in admin
+		const { count, error } = await countTotalUsageLog({
+			usagelog_id: 0,
+			start: null,
+			end: null,
+			is_active: null,
+			lib_user_id: 0,
+			service_type: '',
+			library,
+			section,
+			admin_id: $AdminStore.formData.admin_id
+		});
+
+		if (error) {
+			toast.error(`Error with getting statistics: ${error}`);
+		} else if (count) {
+			$StatisticStore.total_usagelogs = count;
+
+			// const { serviceTypes, error } = await readServiceType();
+			// if (error) {
+			//     return;
+			// } else if (serviceTypes != null) {
+
+			//     $ServiceTypeStore = serviceTypes;
+			//     console.log($ServiceTypeStore)
+
+			//     // for (const service of $ServiceTypeStore) {
+			//     //     console.log(service)
+			//     // }
+			// }
+		}
+		return;
+	}
 </script>
 
 <Toaster />
 
 <div class="flex w-full justify-center">
 	{#if $AdminStore.formData.is_approved}
-		<div class="w-[95%] flex flex-col gap-4">
+		<div class="flex w-[95%] flex-col gap-4">
 			<h1 class="pt-10 text-3xl font-medium">Hello, {$AdminStore.formData.nickname}</h1>
-            <h2 class="text-lg text-[#636363]">Here are your statistics in {data.libraryName}, {librarySection}</h2>
-            <p>Total Usage Logs Supervised: {$StatisticStore.total_usagelogs}</p>
-            <button on:click={getStatistics}>Get Stat</button>
+			<h2 class="text-lg text-[#636363]">
+				Here are your statistics in {data.libraryName}, {librarySection}
+			</h2>
+			<p>Total Usage Logs Supervised: {$StatisticStore.total_usagelogs}</p>
+			<button on:click={getStatistics}>Get Stat</button>
 		</div>
 	{:else}
 		<div class="flex h-full w-full flex-col gap-10 p-20">

--- a/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
@@ -10,17 +10,11 @@
 	import { page } from '$app/stores';
 	import { readServiceType } from '../../../../supabase/ServiceType';
 	import { ServiceTypeStore } from '$lib/stores/ServiceStore';
-	import { supabaseClient } from '$lib/client/SupabaseClient';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import LibraryCombobox from '$lib/components/ui/combobox/library-combobox.svelte';
 	import SectionCombobox from '$lib/components/ui/combobox/section-combobox.svelte';
-	import DatetimePicker from '$lib/components/ui/datetime-picker/datetime-picker.svelte';
 	import DatePicker from '$lib/components/ui/date-picker/date-picker.svelte';
-
-	const routes: Array<string> = $page.url.pathname.split('/');
-	const library: string = routes[1]; // session
-	const section: string = routes[2]; // session
 
 	let selectedLibrary: string = 'engglib1';
 	let selectedSection: string = '';
@@ -85,15 +79,13 @@
 	{#if $AdminStore.formData.is_approved}
 		<div class="flex w-[95%] flex-col gap-4">
 			<h1 class="pt-10 text-3xl font-medium">Hello, {$AdminStore.formData.nickname}</h1>
-			<h2 class="text-lg text-[#636363]">
-				Here is your report
-			</h2>
+			<h2 class="text-lg text-[#636363]">Here is your report</h2>
 			<div class="grid grid-cols-6 gap-2">
 				<LibraryCombobox bind:selectedLibrary onChange={(e) => (selectedLibrary = e)} />
 				<SectionCombobox bind:selectedSection onChange={(e) => (selectedSection = e)} />
 				<Input placeholder="Enter admin nickname" class="max-w-sm" bind:value={selectedAdmin} />
-                <DatePicker bind:selectedDate={selectedStart} placeholder={'Enter start date'}/>
-                <DatePicker bind:selectedDate={selectedEnd}  placeholder={'Enter end date'}/>
+				<DatePicker bind:selectedDate={selectedStart} placeholder={'Enter start date'} />
+				<DatePicker bind:selectedDate={selectedEnd} placeholder={'Enter end date'} />
 				<Button on:click={getStatistics}>Get Statistics</Button>
 			</div>
 			{#each Object.keys($StatisticStore.total_services) as service}

--- a/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
@@ -28,11 +28,11 @@
 	let selectedStart: Date | null = null;
 	let selectedEnd: Date | null = null;
 
-	export let data: { libraryName: string };
-	const librarySection: string = section
-		.split('-')
-		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-		.join(' ');
+	// export let data: { libraryName: string };
+	// const librarySection: string = section
+	// 	.split('-')
+	// 	.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+	// 	.join(' ');
 
 	async function getServiceType() {
 		// gets the service types from the db as it's needed in both admin and user dashboard
@@ -86,9 +86,9 @@
 		<div class="flex w-[95%] flex-col gap-4">
 			<h1 class="pt-10 text-3xl font-medium">Hello, {$AdminStore.formData.nickname}</h1>
 			<h2 class="text-lg text-[#636363]">
-				Here are your statistics in {data.libraryName}, {librarySection}
+				Here is your report
 			</h2>
-			<div class="grid grid-cols-6">
+			<div class="grid grid-cols-6 gap-2">
 				<LibraryCombobox bind:selectedLibrary onChange={(e) => (selectedLibrary = e)} />
 				<SectionCombobox bind:selectedSection onChange={(e) => (selectedSection = e)} />
 				<Input placeholder="Enter admin nickname" class="max-w-sm" bind:value={selectedAdmin} />

--- a/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
+++ b/src/routes/[library]/[section]/admin-dashboard/statistics/+page.svelte
@@ -6,15 +6,23 @@
 	// Backend Imports
 	import { AdminStore } from '$lib/stores/AdminStore';
 	import { StatisticStore } from '$lib/stores/StatisticStore';
-	import { countTotalService, countTotalUsageLog } from '../../../../supabase/UsageLog';
+	import { countTotalService } from '../../../../supabase/UsageLog';
 	import { page } from '$app/stores';
 	import { readServiceType } from '../../../../supabase/ServiceType';
 	import { ServiceTypeStore } from '$lib/stores/ServiceStore';
 	import { supabaseClient } from '$lib/client/SupabaseClient';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import LibraryCombobox from '$lib/components/ui/combobox/library-combobox.svelte';
+	import SectionCombobox from '$lib/components/ui/combobox/section-combobox.svelte';
 
 	const routes: Array<string> = $page.url.pathname.split('/');
 	const library: string = routes[1]; // session
 	const section: string = routes[2]; // session
+
+    let selectedLibrary:string = 'engglib1';
+    let selectedSection:string = '';
+    let selectedAdmin:string = '';
 
 	export let data: { libraryName: string };
 	const librarySection: string = section
@@ -36,45 +44,30 @@
 
 	async function getStatistics() {
 		// gets all statistics for the logged in admin
-		const { count, error } = await countTotalUsageLog({
-			usagelog_id: 0,
-			start: null,
-			end: null,
-			is_active: null,
-			lib_user_id: 0,
-			service_type: '',
-			library,
-			section,
-			admin_id: $AdminStore.formData.admin_id
-		});
+        // console.log(`lib: ${selectedLibrary}, section: ${selectedSection}, admin: ${selectedAdmin}`)
+        $StatisticStore.total_usagelogs = 0;
+        for (const service of $ServiceTypeStore) {
+            if (!service.main_service_type) {
+                const { count, error } = await countTotalService({
+                    usagelog_id: 0,
+                    start: null,
+                    end: null,
+                    is_active: null,
+                    lib_user_id: 0,
+                    service_type: service.service_type,
+                    library: selectedLibrary,
+                    section: selectedSection,
+                    admin_nickname: selectedAdmin,
+                });
 
-		if (error) {
-			toast.error(`Error with getting usage log statistics: ${error}`);
-		} else if (count) {
-			$StatisticStore.total_usagelogs = count;
-
-			for (const service of $ServiceTypeStore) {
-				if (!service.main_service_type) {
-					const { count, error } = await countTotalService({
-						usagelog_id: 0,
-						start: null,
-						end: null,
-						is_active: null,
-						lib_user_id: 0,
-						service_type: service.service_type,
-						library,
-						section,
-						admin_id: $AdminStore.formData.admin_id
-					});
-
-					if (error) {
-						toast.error(`Error with getting service statistics: ${error}`);
-					} else {
-						$StatisticStore.total_services[service.service_type] = count;
-					}
-				}
-			}
-		}
+                if (error) {
+                    toast.error(`Error with getting service statistics: ${error}`);
+                } else {
+                    $StatisticStore.total_services[service.service_type] = count;
+                    $StatisticStore.total_usagelogs += count;
+                }
+            }
+        }
 		return;
 	}
 
@@ -92,13 +85,20 @@
 			<h2 class="text-lg text-[#636363]">
 				Here are your statistics in {data.libraryName}, {librarySection}
 			</h2>
-			<button on:click={getStatistics}>Get Stat</button>
+            <div class="grid grid-cols-4">
+                <LibraryCombobox bind:selectedLibrary={selectedLibrary} onChange={(e) => {selectedLibrary = e; console.log(selectedLibrary)}} />
+                <SectionCombobox bind:selectedSection={selectedSection} onChange={(e) => {selectedSection = e; console.log(selectedSection)}} />
+                <Input placeholder="Enter admin nickname" class="max-w-sm" bind:value={selectedAdmin}/>
+                <Button on:click={getStatistics}>Get Statistics</Button>
+            </div>
+			{#each Object.keys($StatisticStore.total_services) as service}
+				{#if $StatisticStore.total_services[service]}
+                    <p>{service}: {$StatisticStore.total_services[service]}</p>
+                {/if}
+			{/each}
 			{#if $StatisticStore.total_usagelogs}
 				<p>Total Usage Logs Supervised: {$StatisticStore.total_usagelogs}</p>
 			{/if}
-			{#each Object.keys($StatisticStore.total_services) as service}
-				<p>{service}: {$StatisticStore.total_services[service]}</p>
-			{/each}
 		</div>
 	{:else}
 		<div class="flex h-full w-full flex-col gap-10 p-20">

--- a/src/routes/[library]/[section]/auth/login/+page.svelte
+++ b/src/routes/[library]/[section]/auth/login/+page.svelte
@@ -19,6 +19,7 @@
 	import { ServiceTableStore } from '$lib/stores/ServiceStore';
 	import { UsageLogTableStore } from '$lib/stores/UsageLogStore';
 	import { verifyPC } from '../../../../supabase/Verifier';
+	import { StatisticStore } from '$lib/stores/StatisticStore';
 
 	let loginWithRfid: boolean = true;
 	let rfidGlobal: string = '';
@@ -80,6 +81,11 @@
     $ServiceTableStore = [];
     $UsageLogTableStore = [];
     $AdminTableStore = [];
+
+    $StatisticStore = {
+        total_usagelogs: 0,
+        total_services: {}
+    }
 
 	// ----------------------------------------------------------------------------
 

--- a/src/routes/[library]/[section]/student-dashboard/+layout.svelte
+++ b/src/routes/[library]/[section]/student-dashboard/+layout.svelte
@@ -338,7 +338,8 @@
 			lib_user_id: 0,
 			service_type: '',
 			library,
-			section
+			section,
+            admin_id: 0
 		});
 
 		if (error) {

--- a/src/routes/[library]/[section]/student-dashboard/+layout.svelte
+++ b/src/routes/[library]/[section]/student-dashboard/+layout.svelte
@@ -339,7 +339,7 @@
 			service_type: '',
 			library,
 			section,
-            admin_id: 0
+            admin_nickname: ''
 		});
 
 		if (error) {

--- a/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
+++ b/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
@@ -144,7 +144,6 @@
 				$ServiceTypeStore = serviceTypes;
 				$ServiceInfoStore = serviceInfo;
 				$ServiceOptionStore = serviceOption;
-                console.log($ServiceTypeStore)
 			}
 		}
 		return;
@@ -182,7 +181,8 @@
 			lib_user_id: parseInt($UserStore.formData.lib_user_id),
 			service_type: '',
 			library,
-			section
+			section,
+            admin_id: 0
 		});
 
 		if (error) {

--- a/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
+++ b/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
@@ -99,15 +99,15 @@
 						service_type: serviceType.service_type,
 						service_type_id: serviceType.service_type_id,
 						available_number: 0,
-                        total_available_number: 0,
+						total_available_number: 0,
 						service_img_src: `../../../services/${serviceType.service_type}.png`
 					};
-                    serviceOption[serviceType.service_type] = {};
+					serviceOption[serviceType.service_type] = {};
 					serviceOption[serviceType.service_type][serviceType.service_type] = {
-                        type: 'select',
-                        label: serviceType.service_type,
-                        options: [],
-                        variant: 'default'
+						type: 'select',
+						label: serviceType.service_type,
+						options: [],
+						variant: 'default'
 					};
 				}
 			}
@@ -126,7 +126,7 @@
 					// service option store
 					if (serviceOption.hasOwnProperty(service.service_type)) {
 						// service is of main service type
-                        serviceInfo[service.service_type].total_available_number++;
+						serviceInfo[service.service_type].total_available_number++;
 						serviceInfo[service.service_type].available_number++;
 						serviceOption[service.service_type][service.service_type].options.push(service);
 					} else {
@@ -134,12 +134,15 @@
 						const mainServiceType: string = serviceTypes.filter(
 							(value) => value.service_type == service.service_type
 						)[0].main_service_type;
-                        if (mainServiceType == "Umbrella") serviceInfo[mainServiceType].available_number++;
-                        serviceInfo[mainServiceType].total_available_number++;
+						if (mainServiceType == 'Umbrella') serviceInfo[mainServiceType].available_number++;
+						serviceInfo[mainServiceType].total_available_number++;
 						serviceOption[mainServiceType][service.service_type].options.push(service);
 					}
 				}
-                serviceInfo['Discussion Room'].available_number = countDiscRoomAvailability(serviceOption['Discussion Room'], library);
+				serviceInfo['Discussion Room'].available_number = countDiscRoomAvailability(
+					serviceOption['Discussion Room'],
+					library
+				);
 				$ServiceTypeStore = serviceTypes;
 				$ServiceInfoStore = serviceInfo;
 				$ServiceOptionStore = serviceOption;
@@ -181,7 +184,7 @@
 			service_type: '',
 			library,
 			section,
-            admin_id: 0
+			admin_id: 0
 		});
 
 		if (error) {
@@ -189,7 +192,9 @@
 		} else if (usagelogs != null) {
 			let activeUsagelogs: { [key: string]: UsageLogView } = {};
 			for (const usagelog of usagelogs) {
-                const serviceType:string = usagelog.main_service_type ? usagelog.main_service_type : usagelog.service_type;
+				const serviceType: string = usagelog.main_service_type
+					? usagelog.main_service_type
+					: usagelog.service_type;
 				activeUsagelogs[serviceType] = usagelog;
 			}
 

--- a/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
+++ b/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
@@ -77,7 +77,6 @@
 		// and puts the returned values in $ServiceStore
 
 		const { serviceTypes, error } = await readServiceType();
-		serviceTypes?.sort((a, b) => a.service_type_id - b.service_type_id);
 
 		if (error) {
 			toast.error(`Error with reading service types: ${error}`);

--- a/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
+++ b/src/routes/[library]/[section]/student-dashboard/services/+page.svelte
@@ -184,7 +184,7 @@
 			service_type: '',
 			library,
 			section,
-			admin_id: 0
+			admin_nickname: ''
 		});
 
 		if (error) {

--- a/src/routes/supabase/UsageLog.ts
+++ b/src/routes/supabase/UsageLog.ts
@@ -89,20 +89,55 @@ export async function deleteUsageLog(usagelog_id: number): Promise<UsageLogRespo
     };
 }
 
-export async function countTotalUsageLog(filter: UsageLogFilter): Promise<{count:number, error:string|null}> {
+export async function countTotalUsageLog(filter: UsageLogFilter): Promise<{ count: number, error: string | null }> {
     // Counts the usage logs according to filter
     const { count, error } = await supabaseClient
         .from(`public_usagelog_${filter.library}`)
         .select("*", { count: 'exact', head: true })
         .eq('section', filter.section)
         .or(`admin_id1.eq.${filter.admin_id},admin_id2.eq.${filter.admin_id}`)
+
+    if (error) {
+        return {
+            count: 0,
+            error: error.message
+        }
+    }
+
+    return { count: count != null ? count : 0, error: null }
+}
+
+export async function countTotalService(filter: UsageLogFilter): Promise<{ count: number, error: string | null }> {
+    // Counts each service for a specific admin and range of date
+    let query = supabaseClient
+        .from(`public_usagelog_${filter.library}`)
+        .select('*', { count: 'exact' })
+        .or(`service_type.eq.${filter.service_type},main_service_type.eq.${filter.service_type}`)
+
+    if (filter.admin_id) {
+        query = query.or(`admin_id1.eq.${filter.admin_id},admin_id2.eq.${filter.admin_id}`)
+    }
+
+    if (filter.section) {
+        query = query.eq('section', filter.section)
+    }
+
+    if (filter.start) {
+        query = query.gte('start', filter.start);
+    }
+
+    if (filter.end) {
+        query = query.lte('end', filter.end);
+    }
+
+    const { count, error } = await query;
     
     if (error) {
         return {
             count: 0,
             error: error.message
         }
-    } 
-    
+    }
+
     return { count: count != null ? count : 0, error: null }
 }

--- a/src/routes/supabase/UsageLog.ts
+++ b/src/routes/supabase/UsageLog.ts
@@ -89,33 +89,15 @@ export async function deleteUsageLog(usagelog_id: number): Promise<UsageLogRespo
     };
 }
 
-export async function countTotalUsageLog(filter: UsageLogFilter): Promise<{ count: number, error: string | null }> {
-    // Counts the usage logs according to filter
-    const { count, error } = await supabaseClient
-        .from(`public_usagelog_${filter.library}`)
-        .select("*", { count: 'exact', head: true })
-        .eq('section', filter.section)
-        .or(`admin_id1.eq.${filter.admin_id},admin_id2.eq.${filter.admin_id}`)
-
-    if (error) {
-        return {
-            count: 0,
-            error: error.message
-        }
-    }
-
-    return { count: count != null ? count : 0, error: null }
-}
-
 export async function countTotalService(filter: UsageLogFilter): Promise<{ count: number, error: string | null }> {
     // Counts each service for a specific admin and range of date
     let query = supabaseClient
         .from(`public_usagelog_${filter.library}`)
-        .select('*', { count: 'exact' })
+        .select('*', { count: 'exact', })
         .or(`service_type.eq.${filter.service_type},main_service_type.eq.${filter.service_type}`)
 
-    if (filter.admin_id) {
-        query = query.or(`admin_id1.eq.${filter.admin_id},admin_id2.eq.${filter.admin_id}`)
+    if (filter.admin_nickname) {
+        query = query.or(`admin_nickname1.eq.${filter.admin_nickname},admin_nickname2.eq.${filter.admin_nickname}`)
     }
 
     if (filter.section) {
@@ -130,7 +112,8 @@ export async function countTotalService(filter: UsageLogFilter): Promise<{ count
         query = query.lte('end', filter.end);
     }
 
-    const { count, error } = await query;
+    const { data, count, error } = await query;
+    console.log(data)
     
     if (error) {
         return {

--- a/src/routes/supabase/UsageLog.ts
+++ b/src/routes/supabase/UsageLog.ts
@@ -115,7 +115,6 @@ export async function countTotalService(filter: UsageLogFilter): Promise<{ count
     }
 
     const { data, count, error } = await query;
-    console.log(data)
     
     if (error) {
         return {

--- a/src/routes/supabase/UsageLog.ts
+++ b/src/routes/supabase/UsageLog.ts
@@ -89,7 +89,7 @@ export async function deleteUsageLog(usagelog_id: number): Promise<UsageLogRespo
     };
 }
 
-export async function countUsageLog(filter: UsageLogFilter): Promise<{count:number, error:string|null}> {
+export async function countTotalUsageLog(filter: UsageLogFilter): Promise<{count:number, error:string|null}> {
     // Counts the usage logs according to filter
     const { count, error } = await supabaseClient
         .from(`public_usagelog_${filter.library}`)

--- a/src/routes/supabase/UsageLog.ts
+++ b/src/routes/supabase/UsageLog.ts
@@ -2,7 +2,7 @@ import { supabaseClient } from "$lib/client/SupabaseClient";
 import type { UsageLogFilter } from "$lib/dataTypes/EntityFilters";
 import type { UsageLogResponse } from "$lib/dataTypes/EntityResponses";
 
-export async function readUsageLog(filter:UsageLogFilter): Promise<UsageLogResponse> {
+export async function readUsageLog(filter: UsageLogFilter): Promise<UsageLogResponse> {
     // Reads and filters the service_engglib table in the database and returns all corresponding entries
     let midnightToday: Date = new Date();
     midnightToday.setHours(0, 0, 0, 0);
@@ -45,7 +45,7 @@ export async function readUsageLog(filter:UsageLogFilter): Promise<UsageLogRespo
     if (error) {
         return {
             usagelogs: null,
-            error: error.toString()
+            error: error.message
         }
     }
 
@@ -55,14 +55,14 @@ export async function readUsageLog(filter:UsageLogFilter): Promise<UsageLogRespo
     }
 }
 
-export async function updateUsageLog(usagelog:object, usageLogID: number): Promise<UsageLogResponse> {
+export async function updateUsageLog(usagelog: object, usageLogID: number): Promise<UsageLogResponse> {
     // Creates usage log in the usagelog_engglib table
     const { error } = await supabaseClient.from('usagelog_engglib').update(usagelog).eq('usagelog_id', usageLogID)
 
     if (error) {
         return {
             usagelogs: null,
-            error: error.toString()
+            error: error.message
         }
     }
 
@@ -72,14 +72,14 @@ export async function updateUsageLog(usagelog:object, usageLogID: number): Promi
     };
 }
 
-export async function deleteUsageLog(usagelog_id:number): Promise<UsageLogResponse> {
+export async function deleteUsageLog(usagelog_id: number): Promise<UsageLogResponse> {
     // Deletes usagelog record from usagelog_engglib table
     const { error } = await supabaseClient.from('usagelog_engglib').delete().eq('usagelog_id', usagelog_id)
 
     if (error) {
         return {
             usagelogs: null,
-            error: error.toString()
+            error: error.message
         }
     }
 
@@ -87,4 +87,22 @@ export async function deleteUsageLog(usagelog_id:number): Promise<UsageLogRespon
         usagelogs: null,
         error: null,
     };
+}
+
+export async function countUsageLog(filter: UsageLogFilter): Promise<{count:number, error:string|null}> {
+    // Counts the usage logs according to filter
+    const { count, error } = await supabaseClient
+        .from(`public_usagelog_${filter.library}`)
+        .select("*", { count: 'exact', head: true })
+        .eq('section', filter.section)
+        .or(`admin_id1.eq.${filter.admin_id},admin_id2.eq.${filter.admin_id}`)
+    
+    if (error) {
+        return {
+            count: 0,
+            error: error.message
+        }
+    } 
+    
+    return { count: count != null ? count : 0, error: null }
 }


### PR DESCRIPTION
# Updates
I started the backend of the statistics page. Here are the features:

## Admin Dashboard Statistics Page
- Filter for library. The default library is EnggLib 1. The report needs to be generated per library because the usage logs for each library is separated by table. However, this could be changed to enable report generation for all libraries by joining both tables.
- Filter for section.
- Filter for admin. This is an input field because I don't know if admins want to input their admin_id instead. Making a combobox for this would be too much work -^-
- Get Statistics button. Statistics generation need a lot of API calls because each count of services is a separate API call. There is no multiple count API call where we can do one function call and it returns the count of every service.
- Statistics. It's just display how many usage logs were supervised according to the filters given.

![image](https://github.com/user-attachments/assets/d32daa5d-9512-4ccf-b7ea-795dc1bd6822)

@allainerain please help with design t-t hskshkshkshs. 

I'm planning to:
- Add a month or date range filter
- Design the statistics to be in a grid per month
- Create a 'Export to CSV' option.